### PR TITLE
fix bug when new Event are not ensured to have different $id

### DIFF
--- a/src/Schedule.php
+++ b/src/Schedule.php
@@ -54,7 +54,8 @@ class Schedule implements PingableInterface
             $command .= ' ' . $this->compileParameters($parameters);
         }
 
-        $this->events[] = $event = new Event($this->id(), $command);
+        $id = $this->id();
+        $this->events[$id] = $event = new Event($id, $command);
 
         return $event;
     }


### PR DESCRIPTION
New $id Event generated in Scheduler::id() is checked against keys of Scheduler::$events array to ensure that it is unique, however Scheduler::$events is numeric array with autogenerated  inidices in Scheduler::run().

This patch changes Scheduler::$events to associative array with Event::$id being array's key.
